### PR TITLE
fix: register more media keys that apps can use

### DIFF
--- a/tizenbrew-app/TizenBrew/index.html
+++ b/tizenbrew-app/TizenBrew/index.html
@@ -190,6 +190,20 @@
 
             tizen.tvinputdevice.registerKey("MediaPlayPause");
 
+            tizen.tvinputdevice.registerKey('MediaPlay');
+
+            tizen.tvinputdevice.registerKey('MediaPause');
+
+            tizen.tvinputdevice.registerKey('MediaStop');
+
+            tizen.tvinputdevice.registerKey('MediaTrackPrevious');
+
+            tizen.tvinputdevice.registerKey('MediaTrackNext');
+
+            tizen.tvinputdevice.registerKey('MediaRewind');
+            
+            tizen.tvinputdevice.registerKey('MediaFastForward');
+
             tizen.tvinputdevice.registerKey("Back");
 
             tizen.tvinputdevice.registerKey("Exit");


### PR DESCRIPTION
Registering those keys in TizenBrew will allow the apps to listen for the key events. As Tizen API is not available inside a loaded app, register keys in the parent app.