### PR TITLE
Update Vietnamese in translation.js to match the required format.

### DIFF
--- a/tizenbrew-app/TizenBrew/js/translation.js
+++ b/tizenbrew-app/TizenBrew/js/translation.js
@@ -11,7 +11,7 @@ const languages = {
     "es_BO": "Spanish (Español)",
     "de_DE": "German (Deutsch)",
     "nl_NL": "Dutch (Nederlands)",
-    "vi_VN": "Tiếng Việt (Việt Nam)",
+    "vi_VN": "Vietnamese (Tiếng Việt)",
     "pl_PL": "Polish (Polski)"
 };
 


### PR DESCRIPTION
My input for Vietnamese was made before the instruction was clear so I originally thought it was "Language name in native language (Country name in native language)". Sorry for the mistake.
Another idea is to follow the protocol I mentioned, since languages like Portuguese has Portuguese (Portugal) and Portuguese (Brazil)