### PR TITLE
Update translations to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ You can read the [guide](./docs/README.md) to get started with TizenBrew.
 # Making a module
 
 You can read the [guide](./docs/MODULES.md) to make a module for TizenBrew.
+
+# Translations
+
+You can read the [guide](./docs/TRANSLATION.md) to translate TizenBrew UI language into your native language.

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ You can read the [guide](./docs/MODULES.md) to make a module for TizenBrew.
 
 # Translations
 
-You can read the [guide](./docs/TRANSLATION.md) to translate TizenBrew UI language into your native language.
+You can read the [guide](./docs/TRANSLATION.md) to translate TizenBrew into your native language.


### PR DESCRIPTION
Translation guide is not there. The current guide is in the docs folder which may cause difficulties to some people who want to translate to find.