### PR TITLE
Added support for Spanish translation (es_ES)

### DIFF
--- a/tizenbrew-app/TizenBrew/js/translation.js
+++ b/tizenbrew-app/TizenBrew/js/translation.js
@@ -9,6 +9,7 @@ const languages = {
     "da_DK": "Danish (Dansk)",
     "fr_FR": "French (Français)",
     "es_BO": "Spanish (Español)",
+    "es_ES": "Spanish (Español - España)",
     "de_DE": "German (Deutsch)",
     "nl_NL": "Dutch (Nederlands)",
     "vi_VN": "Vietnamese (Tiếng Việt)",

--- a/tizenbrew-app/TizenBrew/lang/es_ES.json
+++ b/tizenbrew-app/TizenBrew/lang/es_ES.json
@@ -1,0 +1,60 @@
+{
+    "mainMenu": {
+        "modules": "Módulos",
+        "description": "Abre tus aplicaciones modificadas favoritas en tu dispositivo Tizen.",
+        "moduleManagerAccess": "Usa el botón <span style=\"color: lightgreen\">{buttons.green}</span> para acceder al administrador de módulos.",
+        "settingsAccess": "Usa el botón <span style=\"color: #0dc1e9\">{buttons.blue}</span> para acceder a los ajustes.",
+        "navigationHelp": "Usa las teclas IZQUIERDA y DERECHA para navegar por la lista.",
+        "autoLaunch": "<p>El inicio automático está habilitado. Pulsa el botón [Flecha Arriba] para deshabilitarlo.</p>"
+    },
+    "service": {
+        "alreadyRunning": "El servicio ya está en ejecución.",
+        "started": "El servicio ha iniciado.",
+        "connected": "El servicio está conectado a la aplicación."
+    },
+    "buttons": {
+        "red": "ROJO",
+        "green": "VERDE",
+        "yellow": "AMARILLO",
+        "blue": "AZUL"
+    },
+    "errors": {
+        "serviceDidntConnectYet": "No puedes lanzar módulos mientras el servicio no se haya conectado aún a la aplicación.",
+        "moduleNotFound": "Error: No se pudo encontrar el módulo {moduleName}.",
+        "crashedServices": "Error: Los siguientes servicios han fallado: {services}.",
+        "debuggingNotEnabled": "Error: No se pudo conectar con el SDB Daemon. ¿Estás seguro de haber cambiado la IP del PC anfitrión a 127.0.0.1? Si lo has hecho, mantén presionado el botón de encendido hasta que veas el logo de Samsung.",
+        "noModules": "Parece que no has instalado ningún módulo aún. Usa el botón [VERDE] para acceder al gestor de módulos."
+    },
+    "moduleManager": {
+        "confirmDelete": "¿Quieres eliminar {packageName}?",
+        "addNPM": "Añadir módulo NPM",
+        "addNPMDesc": "Esto es principalmente para producción y para usuarios.",
+        "addGH": "Añadir módulo GitHub",
+        "addGHDesc": "Esto es principalmente para desarrollo y para desarrolladores.",
+        "addModule": "Añadir módulo",
+        "moduleName": "Nombre del módulo (para {type}):"
+    },
+    "settings": {
+        "autolaunch": "Ajustes de inicio automático",
+        "autolaunchDesc": "Inicia tu módulo favorito automáticamente cuando abras TizenBrew.",
+        "autolaunchService": "Ajustes de inicio automático para servicios",
+        "autolaunchServiceDesc": "Inicia tu servicio favorito automáticamente cuando abras TizenBrew.",
+        "useragent": "Ajustes de User-Agent",
+        "useragentDesc": "Cambia el User-Agent de los módulos de TizenBrew para efectos como arreglar la interfaz en TizenTube.",
+        "enableAutolaunchPrompt": "¿Quieres configurar {packageName} para que se inicie al arrancar?",
+        "disableAutolaunchPrompt": "¿Quieres deshabilitar el inicio automático?",
+        "disableAutolaunch": "Deshabilitar inicio automático",
+        "noModules": "No se encontraron módulos.",
+        "default": "Predeterminado",
+        "worksOnTizen": "(Funciona en Tizen {version}+)",
+        "uaBasedOnDevice": "User-Agent basado en el dispositivo (debería traer algunas características)",
+        "setUaTo": "¿Quieres configurar el User-Agent a {userAgent}?",
+        "uaSetRelaunch": "User-Agent configurado. Reinicia la aplicación para aplicar los cambios.",
+        "uaNegativeEffects": "Ten en cuenta que aunque esto podría tener efectos positivos, también podría haber efectos negativos.",
+        "language": "Ajustes de idioma",
+        "languageDesc": "Cambia el idioma de la aplicación."
+    },
+    "__contributors": [
+        "Kurama71V"
+    ]
+}


### PR DESCRIPTION
## Description
I have added the Spanish translation for Spain (es_ES) to the language settings file. This includes adjustments to the text and the correction of certain terms that are better suited to European Spanish.

## Changes made:
- Added Spanish (es_ES) to the list of available languages.
- Translated key text strings to European Spanish.

## Benefits
This contribution will help make the project more accessible to Spanish-speaking users, especially in Spain.

## Next steps:
- Review if any additional corrections are needed or further testing is required.
