### PR TITLE
Update README with Samsung Certificate Extension installation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,8 @@ To resign TizenBrew, you need to have Tizen Studio installed on your system. You
 
 You also need to have a Samsung certificate. First connect to your TV by following [this](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html).
 
+Install "Samsung Certificate Extension" in the package manager by following [this](https://developer.samsung.com/galaxy-watch-tizen/getting-certificates/install.html).
+
 You can create a Samsung certificate by following [this](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/creating-certificates.html). 
 
 You'll also need to have the TizenBrew package. You can download the TizenBrew package from the [releases page](https://github.com/reisxd/TizenBrew/releases/latest).


### PR DESCRIPTION
Added instructions for installing Samsung Certificate Extension.

I'm waiting for it to finish installing but I think this is needed for the samsung certs.