### PR TITLE
fix(service): normalize autoLaunchServiceList shape for reliable service autolaunch

### DIFF
--- a/tizenbrew-app/TizenBrew/service-nextgen/service/index.js
+++ b/tizenbrew-app/TizenBrew/service-nextgen/service/index.js
@@ -73,9 +73,21 @@ module.exports.onStart = function () {
         args: null
     };
 
+    function normalizeServiceAutoLaunchList(value) {
+        if (Array.isArray(value)) {
+            return value.filter(moduleName => typeof moduleName === 'string' && moduleName.length > 0);
+        }
+
+        if (typeof value === 'string' && value.length > 0) {
+            return [value];
+        }
+
+        return [];
+    }
+
     loadModules().then(modules => {
         modulesCache = modules;
-        const serviceModuleList = readConfig().autoLaunchServiceList;
+        const serviceModuleList = normalizeServiceAutoLaunchList(readConfig().autoLaunchServiceList);
         if (serviceModuleList.length > 0) {
             serviceModuleList.forEach(module => {
                 const service = modules.find(m => m.name === module);
@@ -263,7 +275,7 @@ module.exports.onStart = function () {
                             break;
                         }
                         case 'autolaunchService': {
-                            config.autoLaunchServiceList = module;
+                            config.autoLaunchServiceList = normalizeServiceAutoLaunchList(module);
                             writeConfig(config);
                             break;
                         }


### PR DESCRIPTION
## Summary
This PR fixes a data-shape mismatch in `autoLaunchServiceList` that can break service autolaunch behavior after settings updates.

## Problem
`autoLaunchServiceList` is treated as an array at startup, but the `autolaunchService` action stored a string value directly.

- Startup path expects: `string[]`
- Settings write path was producing: `string` or `''`

This mismatch can lead to inconsistent startup behavior and makes persisted config shape unstable across runs.

## Root Cause
`ModuleAction -> autolaunchService` assigned `config.autoLaunchServiceList = module` where `module` is a scalar value from UI payload.

## Changes
- Added `normalizeServiceAutoLaunchList(value)` helper.
- Normalized persisted value when reading startup autolaunch services.
- Normalized `autolaunchService` writes to always store a list form:
  - selected module -> `[moduleName]`
  - disabled -> `[]`

## Backward Compatibility
Included migration-safe read behavior:
- Existing configs with string values are accepted and normalized at runtime.

## Validation
- Static syntax check: `node --check` on modified service file.
- Manual reasoning checks:
  - enable service autolaunch -> value becomes array
  - disable service autolaunch -> value becomes empty array
  - old string config remains launchable after normalization

## Risk
Low. Scope is limited to autolaunch service config shape normalization.