### PR TITLE
fix(service): remove async race when returning CanLaunchInDebug status

### DIFF
--- a/tizenbrew-app/TizenBrew/service-nextgen/service/index.js
+++ b/tizenbrew-app/TizenBrew/service-nextgen/service/index.js
@@ -46,10 +46,21 @@ module.exports.onStart = function () {
 
     let adbClient;
     let canLaunchInDebug = null;
-    fetch('http://127.0.0.1:8001/api/v2/').then(res => res.json())
-        .then(json => {
-            canLaunchInDebug = (json.device.developerIP === '127.0.0.1' || json.device.developerIP === '1.0.0.127') && json.device.developerMode === '1';
-        });
+
+    function refreshCanLaunchInDebugStatus() {
+        return fetch('http://127.0.0.1:8001/api/v2/')
+            .then(res => res.json())
+            .then(json => {
+                canLaunchInDebug = (json.device.developerIP === '127.0.0.1' || json.device.developerIP === '1.0.0.127') && json.device.developerMode === '1';
+                return canLaunchInDebug;
+            })
+            .catch(() => {
+                canLaunchInDebug = false;
+                return canLaunchInDebug;
+            });
+    }
+
+    refreshCanLaunchInDebugStatus();
     const inDebug = {
         tizenDebug: false,
         webDebug: false,
@@ -161,11 +172,9 @@ module.exports.onStart = function () {
                     break;
                 }
                 case Events.CanLaunchInDebug: {
-                    fetch('http://127.0.0.1:8001/api/v2/').then(res => res.json())
-                        .then(json => {
-                            canLaunchInDebug = (json.device.developerIP === '127.0.0.1' || json.device.developerIP === '1.0.0.127') && json.device.developerMode === '1';
-                        });
-                    wsConn.send(wsConn.Event(Events.CanLaunchInDebug, canLaunchInDebug));
+                    refreshCanLaunchInDebugStatus().then((status) => {
+                        wsConn.send(wsConn.Event(Events.CanLaunchInDebug, status));
+                    });
                     break;
                 }
                 case Events.ReLaunchInDebug: {


### PR DESCRIPTION
## Summary
This PR removes a race condition in `CanLaunchInDebug` handling where stale or null status could be returned to the UI.

## Problem
The current flow refreshed device debug eligibility via `fetch(...)`, but sent the websocket response immediately before the fetch resolved.

As a result, `Events.CanLaunchInDebug` could return:
- stale previous value
- `null` on first request

This can trigger incorrect UI behavior (retries or wrong debug-gate decisions).

## Root Cause
`wsConn.send(...)` was called outside the async completion chain.

## Changes
- Introduced `refreshCanLaunchInDebugStatus()` helper that:
  - fetches current device state
  - updates cached `canLaunchInDebug`
  - returns the resolved boolean
  - falls back to `false` on fetch failure
- `Events.CanLaunchInDebug` now responds only after refresh resolves.
- Kept startup prefetch behavior by calling the helper at service initialization.

## Validation
- Static syntax check: `node --check` on modified service file.
- Behavior check by reasoning:
  - response now deterministic per request
  - no immediate pre-fetch send path remains

## Risk
Low. Change is isolated to eligibility refresh/response timing.