### PR TITLE
fix(debug): align web/app debug status fields between service and UI

### DIFF
--- a/tizenbrew-app/TizenBrew/service-nextgen/service/index.js
+++ b/tizenbrew-app/TizenBrew/service-nextgen/service/index.js
@@ -53,6 +53,7 @@ module.exports.onStart = function () {
     const inDebug = {
         tizenDebug: false,
         webDebug: false,
+        appDebug: false,
         rwiDebug: false
     };
 
@@ -197,6 +198,7 @@ module.exports.onStart = function () {
 
                     if (mdl.packageType === 'app') {
                         inDebug.webDebug = false;
+                        inDebug.appDebug = false;
                         inDebug.tizenDebug = false;
                     } else {
                         currentModule.mainFile = mdl.mainFile;

--- a/tizenbrew-app/TizenBrew/service-nextgen/service/utils/debugger.js
+++ b/tizenbrew-app/TizenBrew/service-nextgen/service/utils/debugger.js
@@ -48,6 +48,7 @@ function startDebugging(port, queuedEvents, clientConn, ip, mdl, inDebug, appCon
 
                 inDebug.tizenDebug = false;
                 inDebug.webDebug = false;
+                inDebug.appDebug = false;
                 inDebug.rwiDebug = false;
 
                 mdl.fullName = '';
@@ -84,7 +85,10 @@ function startDebugging(port, queuedEvents, clientConn, ip, mdl, inDebug, appCon
                     }
                 }
             }
-            if (!isAnotherApp) inDebug.webDebug = true;
+            if (!isAnotherApp) {
+                inDebug.webDebug = true;
+                inDebug.appDebug = true;
+            }
             appControlData = null;
         }).on('error', (err) => {
             if (attempts >= 15) {

--- a/tizenbrew-app/TizenBrew/tizenbrew-ui/src/components/ClientContext.jsx
+++ b/tizenbrew-app/TizenBrew/tizenbrew-ui/src/components/ClientContext.jsx
@@ -5,6 +5,7 @@ const initialState = {
     sharedData: {
         debugStatus: {
             rwiDebug: false,
+            webDebug: false,
             appDebug: false,
             tizenDebug: false
         },

--- a/tizenbrew-app/TizenBrew/tizenbrew-ui/src/components/WebSocketClient.js
+++ b/tizenbrew-app/TizenBrew/tizenbrew-ui/src/components/WebSocketClient.js
@@ -73,14 +73,21 @@ class Client {
             }
 
             case Events.GetDebugStatus: {
+                const normalizedPayload = {
+                    rwiDebug: Boolean(payload && payload.rwiDebug),
+                    webDebug: Boolean(payload && (payload.webDebug || payload.appDebug)),
+                    appDebug: Boolean(payload && (payload.webDebug || payload.appDebug)),
+                    tizenDebug: Boolean(payload && payload.tizenDebug)
+                };
+
                 const state = this.context.state;
-                state.sharedData.debugStatus = payload;
+                state.sharedData.debugStatus = normalizedPayload;
                 this.context.dispatch({
                     type: 'SET_SHARED_DATA',
                     payload: state.sharedData
                 });
 
-                if (!payload.rwiDebug && !payload.appDebug && !payload.tizenDebug) {
+                if (!normalizedPayload.rwiDebug && !normalizedPayload.webDebug && !normalizedPayload.tizenDebug) {
                     this.send({
                         type: Events.CanLaunchInDebug
                     });
@@ -178,6 +185,7 @@ class Client {
     handleCanLaunchModules(payload) {
         const debugStatus = this.context.state.sharedData.debugStatus;
         debugStatus.webDebug = true;
+        debugStatus.appDebug = true;
         this.context.dispatch({
             type: 'SET_DEBUG_STATUS',
             payload: debugStatus


### PR DESCRIPTION
## Summary
This PR aligns debug status field naming between backend service and UI to prevent incorrect state branching.

## Problem
Service state uses `webDebug`, while parts of the UI logic read `appDebug`.

Because of this mismatch, debug-state checks can evaluate incorrectly and launch flow may enter wrong branches.

## Root Cause
Field naming diverged over time across:
- service state payload
- client initial state
- websocket event handling

## Changes
### Service-side compatibility
- Added `appDebug` alongside `webDebug` in the service debug state object.
- Kept both fields synchronized during state transitions (connect/disconnect and app launch reset).

### UI-side normalization
- Added `webDebug` to initial context state.
- Normalized incoming debug payload in websocket client:
  - derives both `webDebug` and `appDebug` from incoming payload (`webDebug || appDebug`)
- Updated gating checks to use normalized `webDebug` path.
- Ensured `handleCanLaunchModules` updates both fields for compatibility.

## Backward Compatibility
Maintains compatibility for both payload shapes:
- old clients expecting `appDebug`
- current service shape with `webDebug`

## Validation
- Static syntax checks:
  - `node --check` service `index.js`
  - `node --check` service `utils/debugger.js`
  - `node --check` UI `WebSocketClient.js`

## Risk
Low to medium. Multi-file change but constrained to debug status mapping/state sync.